### PR TITLE
Platform fixes, (read-only)  feature support

### DIFF
--- a/src/SmallFBX/sfbxDocument.cpp
+++ b/src/SmallFBX/sfbxDocument.cpp
@@ -8,6 +8,7 @@
 #include "sfbxAnimation.h"
 #include "sfbxDocument.h"
 #include "sfbxParser.h"
+#include <cassert>
 
 namespace sfbx {
 

--- a/src/SmallFBX/sfbxDocument.cpp
+++ b/src/SmallFBX/sfbxDocument.cpp
@@ -172,6 +172,68 @@ void Document::importFBXObjects()
         if (auto* t = findAnimationStack(current))
             m_current_take = t;
     }
+
+    global_settings.importFBXObjects(this);
+}
+
+
+void GlobalSettings::importFBXObjects(Document *doc)
+{
+    Node* global_settings = doc->findNode(sfbxS_GlobalSettings);
+    if (!global_settings)
+        return;
+
+//    global_settings->createChild(sfbxS_Version, sfbxI_GlobalSettingsVersion);
+
+    Node *prop = global_settings->findChild(sfbxS_Properties70);
+    if (!prop)
+        prop = global_settings->findChild(sfbxS_Properties);
+    if (!prop)
+        return;
+
+    for (auto& c : prop->getChildren()) {
+        auto propssize = c->getProperties().size();
+        if (c->getName() != sfbxS_P || propssize < 1)
+            continue;
+
+        auto name = c->getProperty(0)->getString();
+
+        //TODO helper, impl all
+        if (name == sfbxS_DefaultCamera) {
+//                        prop->createChild(sfbxS_P, sfbxS_DefaultCamera, sfbxS_KString, "", "", "Producer Perspective");
+            assert(propssize >= 5);
+            camera = c->getProperty(4)->getString();
+        }
+        if (name == sfbxS_TimeSpanStop) {
+//                        prop->createChild(sfbxS_P, sfbxS_DefaultCamera, sfbxS_KString, "", "", "Producer Perspective");
+            assert(propssize >= 5);
+            time_stop = c->getProperty(4)->getValue<int64>();
+        }
+
+//            prop->createChild(sfbxS_P, sfbxS_UpAxis, sfbxS_int sfbxS_int, sfbxS_Integer, "", 1);
+//            prop->createChild(sfbxS_P, sfbxS_UpAxisSign, sfbxS_int, sfbxS_Integer, "", 1);
+//            prop->createChild(sfbxS_P, sfbxS_FrontAxis, sfbxS_int, sfbxS_Integer, "", 2);
+//            prop->createChild(sfbxS_P, sfbxS_FrontAxisSign, sfbxS_int, sfbxS_Integer, "", 1);
+//            prop->createChild(sfbxS_P, sfbxS_CoordAxis, sfbxS_int, sfbxS_Integer, "", 0);
+//            prop->createChild(sfbxS_P, sfbxS_CoordAxisSign, sfbxS_int, sfbxS_Integer, "", 1);
+//            prop->createChild(sfbxS_P, sfbxS_OriginalUpAxis, sfbxS_int, sfbxS_Integer, "", -1);
+//            prop->createChild(sfbxS_P, sfbxS_OriginalUpAxisSign, sfbxS_int, sfbxS_Integer, "", 1);
+
+//            prop->createChild(sfbxS_P, sfbxS_UnitScaleFactor, sfbxS_double, sfbxS_Number, "", 1.0);
+//            prop->createChild(sfbxS_P, sfbxS_OriginalUnitScaleFactor, sfbxS_double, sfbxS_Number, "", 1.0);
+//            prop->createChild(sfbxS_P, sfbxS_AmbientColor, sfbxS_ColorRGB sfbxS_ColorRGB, sfbxS_Color, "", 0.0, 0.0, 0.0);
+
+//            prop->createChild(sfbxS_P, sfbxS_TimeMode, sfbxS_enum, "", "", 0);
+//            prop->createChild(sfbxS_P, sfbxS_TimeProtocol, sfbxS_enum, "", "", 2);
+//            prop->createChild(sfbxS_P, sfbxS_SnapOnFrameMode, sfbxS_enum, "", "", 0);
+//            prop->createChild(sfbxS_P, sfbxS_TimeSpanStart, sfbxS_KTime, sfbxS_Time, "", (int64)0);
+//            prop->createChild(sfbxS_P, sfbxS_CustomFrameRate, sfbxS_double, sfbxS_Number, "", -1.0);
+
+//            prop->createChild(sfbxS_P, sfbxS_TimeMarker, sfbxS_Compound, "", "");
+//            prop->createChild(sfbxS_P, sfbxS_CurrentTimeMarker, sfbxS_int, sfbxS_Integer, "", -1);
+
+    }
+
 }
 
 
@@ -599,7 +661,7 @@ void Document::exportFBXNodes()
         prop->createChild(sfbxS_P, sfbxS_UnitScaleFactor, sfbxS_double, sfbxS_Number, "", 1.0);
         prop->createChild(sfbxS_P, sfbxS_OriginalUnitScaleFactor, sfbxS_double, sfbxS_Number, "", 1.0);
         prop->createChild(sfbxS_P, sfbxS_AmbientColor, sfbxS_ColorRGB sfbxS_ColorRGB, sfbxS_Color, "", 0.0, 0.0, 0.0);
-        prop->createChild(sfbxS_P, sfbxS_DefaultCamera, sfbxS_KString, "", "", "Producer Perspective");
+        prop->createChild(sfbxS_P, sfbxS_DefaultCamera, sfbxS_KString, "", "", this->global_settings.camera);
         prop->createChild(sfbxS_P, sfbxS_TimeMode, sfbxS_enum, "", "", 0);
         prop->createChild(sfbxS_P, sfbxS_TimeProtocol, sfbxS_enum, "", "", 2);
         prop->createChild(sfbxS_P, sfbxS_SnapOnFrameMode, sfbxS_enum, "", "", 0);

--- a/src/SmallFBX/sfbxDocument.h
+++ b/src/SmallFBX/sfbxDocument.h
@@ -20,6 +20,39 @@ enum class FileVersion : int
     Default = Fbx2020,
 };
 
+struct GlobalSettings
+{
+    double unit_scale = 1;
+    std::string camera = "Camera";
+    int64_t time_stop = 0;//sfbxI_TicksPerSecond;
+
+    //TODO
+    //sfbxS_UpAxis, sfbxS_int sfbxS_int, sfbxS_Integer, "", 1);
+    //sfbxS_UpAxisSign, sfbxS_int, sfbxS_Integer, "", 1);
+    //sfbxS_FrontAxis, sfbxS_int, sfbxS_Integer, "", 2);
+    //sfbxS_FrontAxisSign, sfbxS_int, sfbxS_Integer, "", 1);
+    //sfbxS_CoordAxis, sfbxS_int, sfbxS_Integer, "", 0);
+    //sfbxS_CoordAxisSign, sfbxS_int, sfbxS_Integer, "", 1);
+    //sfbxS_OriginalUpAxis, sfbxS_int, sfbxS_Integer, "", -1);
+    //sfbxS_OriginalUpAxisSign, sfbxS_int, sfbxS_Integer, "", 1);
+
+    //sfbxS_UnitScaleFactor, sfbxS_double, sfbxS_Number, "", 1.0);
+    //sfbxS_OriginalUnitScaleFactor, sfbxS_double, sfbxS_Number, "", 1.0);
+    //sfbxS_AmbientColor, sfbxS_ColorRGB sfbxS_ColorRGB, sfbxS_Color, "", 0.0, 0.0, 0.0);
+    //sfbxS_DefaultCamera, sfbxS_KString, "", "", "Producer Perspective");
+    //sfbxS_TimeMode, sfbxS_enum, "", "", 0);
+    //sfbxS_TimeProtocol, sfbxS_enum, "", "", 2);
+    //sfbxS_SnapOnFrameMode, sfbxS_enum, "", "", 0);
+    //sfbxS_TimeSpanStart, sfbxS_KTime, sfbxS_Time, "", (int64)0);
+    //sfbxS_CustomFrameRate, sfbxS_double, sfbxS_Number, "", -1.0);
+
+    //sfbxS_TimeMarker, sfbxS_Compound, "", "");
+    //sfbxS_CurrentTimeMarker, sfbxS_int, sfbxS_Integer, "", -1);
+
+    void exportFBXNodes(Document *doc);
+    void importFBXObjects(Document *doc);
+};
+
 class Document
 {
 public:
@@ -68,6 +101,8 @@ public:
     {
         return count(m_objects, [](auto& p) { return as<T>(p.get()) && p->getID() != 0; });
     }
+
+    GlobalSettings global_settings;
 
 
 public:

--- a/src/SmallFBX/sfbxGeometry.cpp
+++ b/src/SmallFBX/sfbxGeometry.cpp
@@ -165,7 +165,7 @@ void GeomMesh::importFBXObjects()
             checkModes(tmp);
             m_color_layers.push_back(std::move(tmp));
         }
-        else if (n->getName() == sfbxS_LayerLayerElementMaterial) {
+        else if (n->getName() == sfbxS_LayerElementMaterial) {
             // colors
             LayerElementI1 tmp;
             tmp.name = GetChildPropertyString(n, sfbxS_Name);
@@ -291,7 +291,7 @@ void GeomMesh::exportFBXObjects()
             continue;
 
         ++clayers;
-        auto l = n->createChild(sfbxS_LayerLayerElementMaterial);
+        auto l = n->createChild(sfbxS_LayerElementMaterial);
         l->createChild(sfbxS_Version, sfbxI_LayerElementMaterialVersion);
         l->createChild(sfbxS_Name, layer.name);
 
@@ -323,7 +323,7 @@ void GeomMesh::exportFBXObjects()
         }
         if (!m_material_layers.empty()) {
             auto le = l->createChild(sfbxS_LayerElement);
-            le->createChild(sfbxS_Type, sfbxS_LayerLayerElementMaterial);
+            le->createChild(sfbxS_Type, sfbxS_LayerElementMaterial);
             le->createChild(sfbxS_TypedIndex, 0);
         }
     }

--- a/src/SmallFBX/sfbxInternal.h
+++ b/src/SmallFBX/sfbxInternal.h
@@ -93,6 +93,15 @@ inline T GetPropertyValue(Node* node, size_t pi = 0)
     return {};
 }
 
+template<class T, class Dst, sfbxRestrict(!is_RawVector<Dst> && !is_vector<Dst>)>
+inline void GetPropertyValue(Dst& dst, Node* node, size_t pi) //=0
+{
+    if (node) {
+        if (Property* prop = node->getProperty(pi))
+            dst = prop->getValue<T>();
+    }
+}
+
 inline string_view GetPropertyString(Node* node, size_t pi = 0)
 {
     if (node)
@@ -138,6 +147,12 @@ inline T GetChildPropertyValue(Node* node, string_view name, size_t pi = 0)
         return GetPropertyValue<T>(node->findChild(name), pi);
     return {};
 }
+template<class T, class Dst, sfbxRestrict(!(is_RawVector<Dst> || is_vector<Dst>))>
+inline void GetChildPropertyValue(Dst& dst, Node* node, string_view name, size_t pi = 0)
+{
+    if (node)
+        GetPropertyValue<T>(dst, node->findChild(name), pi);
+}
 template<class T, class Dst, sfbxRestrict(is_RawVector<Dst> || is_vector<Dst>)>
 inline void GetChildPropertyValue(Dst& dst, Node* node, string_view name)
 {
@@ -147,7 +162,7 @@ inline void GetChildPropertyValue(Dst& dst, Node* node, string_view name)
 inline string_view GetChildPropertyString(Node* node, string_view name, size_t pi = 0)
 {
     if (node)
-        return GetPropertyString(node->findChild(name));
+        return GetPropertyString(node->findChild(name), pi);
     return {};
 }
 

--- a/src/SmallFBX/sfbxModel.h
+++ b/src/SmallFBX/sfbxModel.h
@@ -248,6 +248,9 @@ public:
     float getAspectRatio() const;
     float getNearPlane() const;
     float getFarPlane() const;
+    float3 getUpVector() const;
+    float3 getTargetPosition() const;
+    bool getAutoClipPlanes() const;
 
     // there is no setFildOfView() because fov is computed by aperture and focal length.
     // focal length can be computed by compute_focal_length() in sfbxMath.h with fov and aperture.
@@ -274,6 +277,9 @@ protected:
     float2 m_aspect{ 1920.0f, 1080.0f };
     float m_near_plane = 0.1f;
     float m_far_plane = 1000.0f;
+    float3 m_up_vector = {0, 1, 0};
+    float3 m_target_position = {0, 0, 0};
+    bool m_auto_clip_planes = false;
 };
 
 

--- a/src/SmallFBX/sfbxObject.cpp
+++ b/src/SmallFBX/sfbxObject.cpp
@@ -201,16 +201,21 @@ void Object::addChild(Object* v)
 {
     if (v) {
         m_children.push_back(v);
+        m_child_property_names.emplace_back();
         v->addParent(this);
     }
 }
-void Object::addChild(Object* v, string_view /*p*/)
+void Object::addChild(Object* v, string_view p)
 {
     addChild(v);
+    if (v) {
+        m_child_property_names.back() = p;
+    }
 }
 
 void Object::eraseChild(Object* v)
 {
+    //TODO m_child_property_names
     if (erase(m_children, v))
         v->eraseParent(this);
 }
@@ -236,6 +241,7 @@ span<Object*> Object::getParents() const  { return make_span(m_parents); }
 span<Object*> Object::getChildren() const { return make_span(m_children); }
 Object* Object::getParent(size_t i) const { return i < m_parents.size() ? m_parents[i] : nullptr; }
 Object* Object::getChild(size_t i) const  { return i < m_children.size() ? m_children[i] : nullptr; }
+const std::string& Object::getChildProp(size_t i) const { static std::string nulls; return i < m_child_property_names.size() ? m_child_property_names[i] : nulls; }
 
 Object* Object::findChild(string_view name) const
 {

--- a/src/SmallFBX/sfbxObject.h
+++ b/src/SmallFBX/sfbxObject.h
@@ -104,6 +104,7 @@ public:
     span<Object*> getChildren() const;
     Object* getParent(size_t i = 0) const;
     Object* getChild(size_t i = 0) const;
+    const std::string& getChildProp(size_t i = 0) const;
     Object* findChild(string_view name) const; // name accepts both full name and display name
 
     void setID(int64 v);
@@ -128,6 +129,7 @@ protected:
 
     std::vector<Object*> m_parents;
     std::vector<Object*> m_children;
+    std::vector<std::string> m_child_property_names;
 };
 
 

--- a/src/SmallFBX/sfbxProperty.cpp
+++ b/src/SmallFBX/sfbxProperty.cpp
@@ -262,6 +262,8 @@ template<> double3 Property::getValue() const { return *(double3*)m_data.data();
 template<> double4 Property::getValue() const { return *(double4*)m_data.data(); }
 template<> double4x4 Property::getValue() const { return *(double4x4*)m_data.data(); }
 
+template<> string_view Property::getValue() const { return getString(); }
+
 template<> span<int16>   Property::getArray() const { convert(PropertyType::Int16Array); return make_span((int16*)m_data.data(), getArraySize()); }
 template<> span<int32>   Property::getArray() const { convert(PropertyType::Int32Array); return make_span((int32*)m_data.data(), getArraySize()); }
 template<> span<int64>   Property::getArray() const { convert(PropertyType::Int64Array); return make_span((int64*)m_data.data(), getArraySize()); }

--- a/src/SmallFBX/sfbxProperty.cpp
+++ b/src/SmallFBX/sfbxProperty.cpp
@@ -89,7 +89,7 @@ void Property::read(std::istream& is)
         else if (encoding == 1) {
             RawVector<char> compressed(src_size);
             readv(is, compressed.data(), src_size);
-            uncompress2((Bytef*)m_data.data(), &dest_size, (const Bytef*)compressed.data(), &src_size);
+            uncompress((Bytef*)m_data.data(), &dest_size, (const Bytef*)compressed.data(), src_size);
         }
     }
 }

--- a/src/SmallFBX/sfbxTokens.h
+++ b/src/SmallFBX/sfbxTokens.h
@@ -195,7 +195,7 @@
 #define sfbxS_LayerElementNormal        "LayerElementNormal"
 #define sfbxS_LayerElementUV            "LayerElementUV"
 #define sfbxS_LayerElementColor         "LayerElementColor"
-#define sfbxS_LayerLayerElementMaterial "LayerElementMaterial"
+#define sfbxS_LayerElementMaterial      "LayerElementMaterial"
 #define sfbxS_MappingInformationType    "MappingInformationType"
 #define sfbxS_ReferenceInformationType  "ReferenceInformationType"
 #define sfbxS_Layer                     "Layer"

--- a/src/SmallFBX/sfbxTokens.h
+++ b/src/SmallFBX/sfbxTokens.h
@@ -56,7 +56,7 @@
 #define sfbxS_Millisecond       "Millisecond"
 #define sfbxS_UserData          "UserData"
 #define sfbxS_Type              "Type"
-#define sfbxS_TypeIndex         "TypeIndex"
+#define sfbxS_TypedIndex         "TypedIndex"
 #define sfbxS_TypeFlags         "TypeFlags"
 #define sfbxS_Null              "Null"
 #define sfbxS_Skeleton          "Skeleton"

--- a/src/SmallFBX/sfbxTokens.h
+++ b/src/SmallFBX/sfbxTokens.h
@@ -226,6 +226,9 @@
 #define sfbxS_FilmOffsetY           "FilmOffsetY"
 #define sfbxS_NearPlane             "NearPlane"
 #define sfbxS_FarPlane              "FarPlane"
+#define sfbxS_UpVector              "UpVector"
+#define sfbxS_InterestPosition      "InterestPosition"
+#define sfbxS_AutoComputeClipPanes  "AutoComputeClipPanes"
 
 #define sfbxS_filmboxTypeID         "filmboxTypeID"
 #define sfbxS_lockInfluenceWeights  "lockInfluenceWeights"


### PR DESCRIPTION
RFC, the minimal changes to support some missing/important functionality 
Caveats: Some TODOs, mostly supports only reading, writing/modyfing scene is not implemented, only the subset of properties that were needed is read\exposed.

- Platform fixes   

(read-only)  feature support:
- geometry shading layers
- mapping/reference modes
- global scene settings(stub except for default camera)
- extended camera properties
- texture attachment "targets"